### PR TITLE
Add info about RPM package

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ Both Brotli library and nginx module are under active development.
 
 ## Installation
 
+### CentOS / RHEL 7
+
+    yum install https://extras.getpagespeed.com/release-el7-latest.rpm
+    yum install nginx nginx-module-nbr
+    
+Follow installation package prompts to enable the dynamic Brotli modules in `nginx.conf`:
+
+    load_module modules/ngx_http_brotli_filter_module.so;
+    load_module modules/ngx_http_brotli_static_module.so;
+
+### Other Platforms
+
     $ cd nginx-1.x.x
     $ ./configure --add-module=/path/to/ngx_brotli
     $ make && make install


### PR DESCRIPTION
This module is one of the reasons why people compile nginx manually, resulting in outdated and unmaintained nginx installation over time.

Having it available as RPM package will save the hassle of installing compilation software, compiling nginx and facilitate easy future updates.

More about the yum repository for CentOS / RedHat 7 [here](https://www.getpagespeed.com/redhat)